### PR TITLE
Python 3 compatibility

### DIFF
--- a/widgets/memoryprofilergui.py
+++ b/widgets/memoryprofilergui.py
@@ -418,7 +418,7 @@ class MemoryProfilerDataTree(QTreeWidget):
                 if l == '':
                     break
                 # split string (discard empty strings using filter)
-                stuff = filter(None, l.split(' '))
+                stuff = list(filter(None, l.split(' ')))
                 # get line number, mem usage, and mem increment
                 lineno = int(stuff[0])
                 if len(stuff) >= 5 and stuff[2] == 'MiB':


### PR DESCRIPTION
filter() returns an iterator in Python 3, instead of a list, and the code crashes. I enclosed filter() inside a list() to make the program work in Python 3 too.
